### PR TITLE
Fix #21: Add fallback for multi-monitor detection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5228,6 +5228,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-positioner"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02dcd56dd4797bd4d6c4c658daed40ce563176f92df90fbd2c904ce145de17ef"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "tauri-plugin-process"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5821,6 +5836,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-notification",
+ "tauri-plugin-positioner",
  "tauri-plugin-process",
  "tauri-plugin-store",
  "tauri-plugin-updater",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-store = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-positioner = { version = "2", features = ["tray-icon"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"


### PR DESCRIPTION
## Summary

- Added `find_monitor_at_point()` helper function with robust monitor detection
- Primary approach: Uses Tauri's `monitor_from_point()` API (works in most cases)
- Fallback: Manually iterates through `available_monitors()` and checks if cursor is within bounds
- Added debug logging to track when fallback is used

## Problem

`monitor_from_point()` sometimes returns `None` even when the cursor is clearly on a monitor, causing the popup to fall back to the primary monitor's top-right position instead of appearing near the cursor.

## Solution

The new `find_monitor_at_point()` function tries the direct API first, and if it fails, searches through all available monitors to find the one containing the cursor position. This provides a reliable fallback for multi-monitor setups.

## Test Plan

- [ ] On single monitor: verify popup appears near cursor
- [ ] On multi-monitor: verify popup appears near cursor on each monitor
- [ ] Check logs for "Found monitor via fallback" messages when fallback is triggered

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)