### PR TITLE
Fix #23: Prevent global shortcut from triggering twice

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Emitter, Manager, RunEvent, WindowEvent,
 };
-use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
 static POPUP_READY: AtomicBool = AtomicBool::new(false);
 
@@ -509,7 +509,14 @@ pub fn run() {
             // Register ⌘J global shortcut (main window)
             let shortcut = Shortcut::new(Some(Modifiers::SUPER), Code::KeyJ);
             app.global_shortcut()
-                .on_shortcut(shortcut, |app, _shortcut, _event| {
+                .on_shortcut(shortcut, |app, _shortcut, event| {
+                    // WHY: tauri-plugin-global-shortcut fires twice (Pressed + Released).
+                    // Only handle Pressed to prevent duplicate translation requests.
+                    // See: https://github.com/tauri-apps/plugins-workspace/issues/1748
+                    if event.state != ShortcutState::Pressed {
+                        return;
+                    }
+
                     // Capture clipboard content BEFORE simulating copy
                     let original_clipboard = arboard::Clipboard::new()
                         .ok()
@@ -530,7 +537,14 @@ pub fn run() {
             let popup_shortcut =
                 Shortcut::new(Some(Modifiers::CONTROL | Modifiers::ALT), Code::KeyJ);
             app.global_shortcut()
-                .on_shortcut(popup_shortcut, |app, _shortcut, _event| {
+                .on_shortcut(popup_shortcut, |app, _shortcut, event| {
+                    // WHY: tauri-plugin-global-shortcut fires twice (Pressed + Released).
+                    // Only handle Pressed to prevent duplicate translation requests.
+                    // See: https://github.com/tauri-apps/plugins-workspace/issues/1748
+                    if event.state != ShortcutState::Pressed {
+                        return;
+                    }
+
                     // Capture clipboard content BEFORE simulating copy
                     let original_clipboard = arboard::Clipboard::new()
                         .ok()


### PR DESCRIPTION
## Summary

- Fixes global shortcut (⌘J, ⌃⌥J) firing twice per single key press
- The `tauri-plugin-global-shortcut` handler fires for both `Pressed` and `Released` states
- Added guard to only handle `Pressed` state, ignoring `Released`

## Root Cause

The `tauri-plugin-global-shortcut` plugin dispatches the handler for both key states. From the logs in the issue, the two triggers were ~754ms apart, which corresponds to the key press and release timing.

Reference: https://github.com/tauri-apps/plugins-workspace/issues/1748

## Changes

- Added `ShortcutState` import from `tauri_plugin_global_shortcut`
- Added early return when `event.state != ShortcutState::Pressed` in both shortcut handlers

## Test plan

- [ ] Press ⌘J once and verify only one translation request is made
- [ ] Press ⌃⌥J once and verify only one popup translation is triggered
- [ ] Check logs to confirm single correlation ID per shortcut press

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)